### PR TITLE
Improve wording of --no_warning help

### DIFF
--- a/src/aesophia_cli.erl
+++ b/src/aesophia_cli.erl
@@ -26,7 +26,7 @@
     , {decode_value, undefined, "decode_value", string, "Decode a Sophia value from FATE data (cb_...)"}
     , {value_type, undefined, "value_type", string, "Sophia type of/for encoded/decoded value"}
     , {include_path, $i, "include_path", string, "Explicit include path"}
-    , {no_warning, $w, "no_warning", string,
+    , {warning_kind, $w, "no_warning", string,
         "Disabled warnings; " ++ string:join([W || {W, _} <- all_warnings()], " | ")}
     , {error_warning, $e, "error_warning", undefined, "Report warnings as errors"}
     , {to_validate, undefined, "validate", string,


### PR DESCRIPTION
Before
```
$ ./aesophia_cli -h  
Usage: aesophia_cli [<src_file>] [-h] [--create_json_aci]
                    [--create_stub_aci] [--no_code] [--create_calldata]
                    [--call <create_calldata_call>]
                    [-w <no_warning>] [-e] [--validate <to_validate>]
```
After
```
$ ./aesophia_cli -h  
Usage: aesophia_cli [<src_file>] [-h] [--create_json_aci]
                    [--create_stub_aci] [--no_code] [--create_calldata]
                    [-w <warning_kind>] [-e] [--validate <to_validate>]
```

This PR is supported by the Æternity Crypto Foundation